### PR TITLE
Replace Deprecated Comment Syntax

### DIFF
--- a/specifications_phrase_descriptions.txt
+++ b/specifications_phrase_descriptions.txt
@@ -1184,7 +1184,7 @@ Example: b-i-b am no-space bee generate h-h counts h-h from h-h integer h-h to h
 ----
 
 description-for-phrase-dashrep-comments-ignored:
-This phrase contains text that the translation process has identified as comments. s-n Comments are contained within the text b-i-b combee b-i-e and b-i-b comenn b-i-e no-space , but these delimiters cannot be nested, so this definition can be useful for debugging.
+This phrase contains text that the translation process has identified as comments. s-n Comments are contained within the text b-i-b com no-space bee b-i-e and b-i-b com no space enn b-i-e no-space , but these delimiters cannot be nested, so this definition can be useful for debugging.
 ----
 
 description-for-phrase-ambee:

--- a/specifications_phrase_descriptions.txt
+++ b/specifications_phrase_descriptions.txt
@@ -1184,7 +1184,7 @@ Example: b-i-b am no-space bee generate h-h counts h-h from h-h integer h-h to h
 ----
 
 description-for-phrase-dashrep-comments-ignored:
-This phrase contains text that the translation process has identified as comments. s-n Comments are contained within the text b-i-b * no-space h-h h-h h-h no-space b-i-e and b-i-b no-space h-h h-h h-h no-space * b-i-e no-space , but these delimiters cannot be nested, so this definition can be useful for debugging.
+This phrase contains text that the translation process has identified as comments. s-n Comments are contained within the text b-i-b combee b-i-e and b-i-b comenn b-i-e no-space , but these delimiters cannot be nested, so this definition can be useful for debugging.
 ----
 
 description-for-phrase-ambee:


### PR DESCRIPTION
[comment]: # (https://github.com/cpsolver/Dashrep-language/pull/9)

Hi Richard (@cpsolver),

The [Dashrep.Org](https://dashrep.org/) home page has the following phrase description for *dashrep-comments-ignored* in the __Debugging-support phrases__ section:

![dashrep-comments-ignored-text](https://github.com/user-attachments/assets/886210e4-0157-4992-9740-d527153a34ec)

The text says: `Comments are contained within the text *--- and ---*, but these delimiters cannot be nested ...`

Since this syntax is now deprecated, I have replaced `*---` with `combee` and `---*` with `comenn`, respectively, in this phrase description in the **specifications_phrase_descriptions.txt** file.

Kind Regards,
Liam