### PR TITLE
Reword Description of delete-listed-phrases

### DIFF
--- a/specifications_phrase_descriptions.txt
+++ b/specifications_phrase_descriptions.txt
@@ -1068,7 +1068,7 @@ The phrases continue to exist, but their definitions are empty.
 ----
 
 description-for-phrase-delete-listed-phrases:
-This action deletes (removes) the phrases that are named in the specified phrase. s-n This phrase is related to the action b-i-b clear h-h listed h-h phrases b-i-e except that instead of just clearing the definition, this delete version removes (deletes) the phrase so that it will not be recognized. s-n
+This action deletes (removes) the phrases that are named in the specified phrase. s-n This action is related to b-i-b clear h-h listed h-h phrases b-i-e (noted above) except that instead of just clearing the definition, it removes (deletes) the phrase so that it will not be recognized. s-n
 This action is useful when the text being expanded contains phrases that should remain in the text if they are not defined, instead of being replaced by their empty definitions.
 ----
 


### PR DESCRIPTION
[comment]: # (https://github.com/cpsolver/Dashrep-language/pull/10)

Hi Richard (@cpsolver),

On [Dashrep.Org](https://dashrep.org/#delete-listed-phrases), the **delete-listed-phrases** is described in one place as a phrase rather than an action. 

This pull request corrects this, and also rewords the remainder of the sentence.

Kind Regards,
Liam