### PR TITLE
Update raw code for chmod (italics)

### DIFF
--- a/specifications_phrase_descriptions.txt
+++ b/specifications_phrase_descriptions.txt
@@ -593,17 +593,17 @@ location-of-read-file
 ----
 
 description-for-phrase-set-file-permission-public-read:
-This action changes the protection of the specified file to allow global read access. s-n It does not allow global write access. s-n It is equivalent to the Linux command i-b chmod 0644 i-e no-space . s-n
+This action changes the protection of the specified file to allow global read access. s-n It does not allow global write access. s-n It is equivalent to the Linux command italics-begin chmod 0644 italics-end no-space . s-n
 location-of-read-file
 ----
 
 description-for-phrase-set-file-permission-private:
-This action changes the protection of the specified file to be private, which means no global read or write access. s-n It is equivalent to the Linux command i-b chmod 0600 i-e no-space . s-n
+This action changes the protection of the specified file to be private, which means no global read or write access. s-n It is equivalent to the Linux command italics-begin chmod 0600 italics-end no-space . s-n
 location-of-read-file
 ----
 
 description-for-phrase-set-file-permission-private-but-executable:
-This action changes the protection of the specified file to allow global executable access, but without global read access. s-n It is equivalent to the Linux command i-b chmod 0711 i-e no-space . s-n
+This action changes the protection of the specified file to allow global executable access, but without global read access. s-n It is equivalent to the Linux command italics-begin chmod 0711 italics-end no-space . s-n
 location-of-read-file
 ----
 


### PR DESCRIPTION
[comment]: # (https://github.com/cpsolver/Dashrep-language/pull/11)

Hi Richard (@cpsolver),

Raw code is appearing on the [Dashrep.Org](https://dashrep.org/#set-file-permission-public-read) page for the three phrases relating to "set-file-permission" where the phrase is the equivalent to a specific use of the Linux "chmod" command. This can be seen here:

![raw-code-in-chmod-usage](https://github.com/user-attachments/assets/ff137ce1-cc80-4513-ba6d-2547d1937844)

The text reads: ` i-b chmod 0644 i-e`. There is no phrase for "i-b" or "i-e" (presumably meant to be "italics begin" and "italics end"). 

I have therefore corrected the three occurrences for "i-b" / "i-e" in the different uses of the "chmod" command.

Kind Regards,
Liam